### PR TITLE
Catch errors in the underlying modbus server

### DIFF
--- a/src/nodes/modbusServer.js
+++ b/src/nodes/modbusServer.js
@@ -146,6 +146,9 @@ module.exports = function (RED) {
         };
         try {
             node.modbusServerTCP = new ModbusRTU.ServerTCP(apiMethods, node.options);
+            node.modbusServerTCP._server.on('error', err => {
+                node.error(err);
+            });
             node.modbusServerTCP.on('socketError', err => {
                 node.error(err);
             });


### PR DESCRIPTION
There are errors/exceptions that are not caught by the modbusServerTCP socketError or error listener, for example, if the IP address:port combination is not available.